### PR TITLE
__builtin_bswap16 presence check for (older) GCCs that don't support it

### DIFF
--- a/src/libsais.c
+++ b/src/libsais.c
@@ -150,7 +150,11 @@ typedef struct LIBSAIS_UNBWT_CONTEXT
 
 #if defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
     #if defined(__GNUC__) || defined(__clang__)
-        #define libsais_bswap16(x) (__builtin_bswap16(x))
+        #if defined(__builtin_bswap16)
+            #define libsais_bswap16(x) (__builtin_bswap16(x))
+        #else
+            #define libsais_bswap16(x) ((uint16_t)(x >> 8) | (uint16_t)(x << 8))
+        #endif
     #elif defined(_MSC_VER) && !defined(__INTEL_COMPILER)
         #define libsais_bswap16(x) (_byteswap_ushort(x))
     #else

--- a/src/libsais64.c
+++ b/src/libsais64.c
@@ -151,7 +151,11 @@ typedef struct LIBSAIS_UNBWT_CONTEXT
 
 #if defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
     #if defined(__GNUC__) || defined(__clang__)
-        #define libsais64_bswap16(x) (__builtin_bswap16(x))
+        #if defined(__builtin_bswap16)
+            #define libsais_bswap16(x) (__builtin_bswap16(x))
+        #else
+            #define libsais_bswap16(x) ((uint16_t)(x >> 8) | (uint16_t)(x << 8))
+        #endif
     #elif defined(_MSC_VER) && !defined(__INTEL_COMPILER)
         #define libsais64_bswap16(x) (_byteswap_ushort(x))
     #else


### PR DESCRIPTION
[__builtin_bswap16(x)](https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html) is gcc and clang built-in 16-bit byte swap macro. In `libsais` it is chosen by preprocessor if `__GNUC__` or `__clang__` are defined but `__builtin_bswap16(x)` is not present in every gcc even though `__GNUC__` is defined.
Although as it's been apparently [patched](https://gcc.gnu.org/bugzilla/attachment.cgi?id=26946) in new gcc but it is important to be aware of the fact that checking for `__GNUC__` is not sufficient indicator of the built-in presence. Hence the pull request.
