### PR TITLE
Fix fatal bug in libsais64_convert_inplace_64u_to_32u

### DIFF
--- a/src/libsais64.c
+++ b/src/libsais64.c
@@ -6252,7 +6252,7 @@ static void libsais64_convert_inplace_32u_to_64u(uint32_t * V, fast_sint_t omp_b
     }
 }
 
-static void libsais64_convert_inplace_64u_to_32u(uint64_t * V, fast_sint_t omp_block_start, fast_sint_t omp_block_size)
+static void libsais64_convert_inplace_64u_to_32u(uint32_t * V, fast_sint_t omp_block_start, fast_sint_t omp_block_size)
 {
     fast_sint_t i, j;
     for (i = omp_block_start, j = omp_block_start + omp_block_size; i < j; i += 1) 
@@ -6304,7 +6304,7 @@ static sa_sint_t libsais64_main_32s_recursion(sa_sint_t * RESTRICT T, sa_sint_t 
         sa_sint_t new_fs = (fs + fs + n + n) <= INT32_MAX ? (fs + fs + n) : INT32_MAX - n;
         if ((new_fs / k >= 4) || (new_fs >= fs))
         {
-            libsais64_convert_inplace_64u_to_32u((uint64_t *)T, 0, n);
+            libsais64_convert_inplace_64u_to_32u((uint32_t *)T, 0, n);
 
 #if defined(LIBSAIS_OPENMP)
             sa_sint_t index = libsais_int_omp((int32_t *)T, (int32_t *)SA, (int32_t)n, (int32_t)k, (int32_t)new_fs, (int32_t)threads);


### PR DESCRIPTION
v2.7.4 modified libsais64_convert_inplace_64u_to_32u to accept only a single pointer to an array of uint64_t of length n. This results in a segmentation fault due to reading past the end of this array, in particular reading elements (i+i+1) for i < n. Overall, this leads to libsais64 failing for any input with length > 2^32. libsais64_convert_inplace_64u_to_32u should instead view the array as an array of uint32_t (of length 2n), which was true in earlier versions that accepted two pointers.