### PR TITLE
Fix gcc14 error about implicit function 'max'

### DIFF
--- a/src/libsais.c
+++ b/src/libsais.c
@@ -31,6 +31,7 @@ Please see the file LICENSE for full copyright information.
 
 #if defined(LIBSAIS_OPENMP)
     #include <omp.h>
+    #include <sys/param.h>
 #else
     #define UNUSED(_x)                  (void)(_x)
 #endif
@@ -2204,7 +2205,7 @@ static void libsais_partial_sorting_scan_left_to_right_8u_block_place(sa_sint_t 
 static sa_sint_t libsais_partial_sorting_scan_left_to_right_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT buckets, sa_sint_t d, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -3036,7 +3037,7 @@ static void libsais_partial_sorting_scan_right_to_left_8u_block_place(sa_sint_t 
 static sa_sint_t libsais_partial_sorting_scan_right_to_left_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT buckets, sa_sint_t d, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4776,7 +4777,7 @@ static void libsais_final_sorting_scan_left_to_right_32s_block_sort(const sa_sin
 static void libsais_final_bwt_scan_left_to_right_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4830,7 +4831,7 @@ static void libsais_final_bwt_scan_left_to_right_8u_block_omp(const uint8_t * RE
 static void libsais_final_bwt_aux_scan_left_to_right_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t rm, sa_sint_t * RESTRICT I, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4884,7 +4885,7 @@ static void libsais_final_bwt_aux_scan_left_to_right_8u_block_omp(const uint8_t 
 static void libsais_final_sorting_scan_left_to_right_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5431,7 +5432,7 @@ static void libsais_final_sorting_scan_right_to_left_32s_block_sort(const sa_sin
 static void libsais_final_bwt_scan_right_to_left_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5485,7 +5486,7 @@ static void libsais_final_bwt_scan_right_to_left_8u_block_omp(const uint8_t * RE
 static void libsais_final_bwt_aux_scan_right_to_left_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t rm, sa_sint_t * RESTRICT I, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5539,7 +5540,7 @@ static void libsais_final_bwt_aux_scan_right_to_left_8u_block_omp(const uint8_t 
 static void libsais_final_sorting_scan_right_to_left_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)

--- a/src/libsais16.c
+++ b/src/libsais16.c
@@ -31,6 +31,7 @@ Please see the file LICENSE for full copyright information.
 
 #if defined(LIBSAIS_OPENMP)
     #include <omp.h>
+    #include <sys/param.h>
 #else
     #define UNUSED(_x)                  (void)(_x)
 #endif
@@ -2182,7 +2183,7 @@ static void libsais16_partial_sorting_scan_left_to_right_16u_block_place(sa_sint
 static sa_sint_t libsais16_partial_sorting_scan_left_to_right_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT buckets, sa_sint_t d, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -3014,7 +3015,7 @@ static void libsais16_partial_sorting_scan_right_to_left_16u_block_place(sa_sint
 static sa_sint_t libsais16_partial_sorting_scan_right_to_left_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT buckets, sa_sint_t d, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4754,7 +4755,7 @@ static void libsais16_final_sorting_scan_left_to_right_32s_block_sort(const sa_s
 static void libsais16_final_bwt_scan_left_to_right_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4808,7 +4809,7 @@ static void libsais16_final_bwt_scan_left_to_right_16u_block_omp(const uint16_t 
 static void libsais16_final_bwt_aux_scan_left_to_right_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t rm, sa_sint_t * RESTRICT I, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4862,7 +4863,7 @@ static void libsais16_final_bwt_aux_scan_left_to_right_16u_block_omp(const uint1
 static void libsais16_final_sorting_scan_left_to_right_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5409,7 +5410,7 @@ static void libsais16_final_sorting_scan_right_to_left_32s_block_sort(const sa_s
 static void libsais16_final_bwt_scan_right_to_left_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5463,7 +5464,7 @@ static void libsais16_final_bwt_scan_right_to_left_16u_block_omp(const uint16_t 
 static void libsais16_final_bwt_aux_scan_right_to_left_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t rm, sa_sint_t * RESTRICT I, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5517,7 +5518,7 @@ static void libsais16_final_bwt_aux_scan_right_to_left_16u_block_omp(const uint1
 static void libsais16_final_sorting_scan_right_to_left_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)

--- a/src/libsais16x64.c
+++ b/src/libsais16x64.c
@@ -32,6 +32,7 @@ Please see the file LICENSE for full copyright information.
 
 #if defined(LIBSAIS_OPENMP)
     #include <omp.h>
+    #include <sys/param.h>
 #else
     #define UNUSED(_x)                  (void)(_x)
 #endif
@@ -2152,7 +2153,7 @@ static void libsais16x64_partial_sorting_scan_left_to_right_16u_block_place(sa_s
 static sa_sint_t libsais16x64_partial_sorting_scan_left_to_right_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT buckets, sa_sint_t d, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -2984,7 +2985,7 @@ static void libsais16x64_partial_sorting_scan_right_to_left_16u_block_place(sa_s
 static sa_sint_t libsais16x64_partial_sorting_scan_right_to_left_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT buckets, sa_sint_t d, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4724,7 +4725,7 @@ static void libsais16x64_final_sorting_scan_left_to_right_32s_block_sort(const s
 static void libsais16x64_final_bwt_scan_left_to_right_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4778,7 +4779,7 @@ static void libsais16x64_final_bwt_scan_left_to_right_16u_block_omp(const uint16
 static void libsais16x64_final_bwt_aux_scan_left_to_right_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t rm, sa_sint_t * RESTRICT I, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4832,7 +4833,7 @@ static void libsais16x64_final_bwt_aux_scan_left_to_right_16u_block_omp(const ui
 static void libsais16x64_final_sorting_scan_left_to_right_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5379,7 +5380,7 @@ static void libsais16x64_final_sorting_scan_right_to_left_32s_block_sort(const s
 static void libsais16x64_final_bwt_scan_right_to_left_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5433,7 +5434,7 @@ static void libsais16x64_final_bwt_scan_right_to_left_16u_block_omp(const uint16
 static void libsais16x64_final_bwt_aux_scan_right_to_left_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t rm, sa_sint_t * RESTRICT I, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5487,7 +5488,7 @@ static void libsais16x64_final_bwt_aux_scan_right_to_left_16u_block_omp(const ui
 static void libsais16x64_final_sorting_scan_right_to_left_16u_block_omp(const uint16_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)

--- a/src/libsais64.c
+++ b/src/libsais64.c
@@ -32,6 +32,7 @@ Please see the file LICENSE for full copyright information.
 
 #if defined(LIBSAIS_OPENMP)
     #include <omp.h>
+    #include <sys/param.h>
 #else
     #define UNUSED(_x)                  (void)(_x)
 #endif
@@ -2174,7 +2175,7 @@ static void libsais64_partial_sorting_scan_left_to_right_8u_block_place(sa_sint_
 static sa_sint_t libsais64_partial_sorting_scan_left_to_right_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT buckets, sa_sint_t d, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -3006,7 +3007,7 @@ static void libsais64_partial_sorting_scan_right_to_left_8u_block_place(sa_sint_
 static sa_sint_t libsais64_partial_sorting_scan_right_to_left_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT buckets, sa_sint_t d, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4746,7 +4747,7 @@ static void libsais64_final_sorting_scan_left_to_right_32s_block_sort(const sa_s
 static void libsais64_final_bwt_scan_left_to_right_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4800,7 +4801,7 @@ static void libsais64_final_bwt_scan_left_to_right_8u_block_omp(const uint8_t * 
 static void libsais64_final_bwt_aux_scan_left_to_right_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t rm, sa_sint_t * RESTRICT I, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -4854,7 +4855,7 @@ static void libsais64_final_bwt_aux_scan_left_to_right_8u_block_omp(const uint8_
 static void libsais64_final_sorting_scan_left_to_right_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5401,7 +5402,7 @@ static void libsais64_final_sorting_scan_right_to_left_32s_block_sort(const sa_s
 static void libsais64_final_bwt_scan_right_to_left_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5455,7 +5456,7 @@ static void libsais64_final_bwt_scan_right_to_left_8u_block_omp(const uint8_t * 
 static void libsais64_final_bwt_aux_scan_right_to_left_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t rm, sa_sint_t * RESTRICT I, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)
@@ -5509,7 +5510,7 @@ static void libsais64_final_bwt_aux_scan_right_to_left_8u_block_omp(const uint8_
 static void libsais64_final_sorting_scan_right_to_left_8u_block_omp(const uint8_t * RESTRICT T, sa_sint_t * RESTRICT SA, sa_sint_t k, sa_sint_t * RESTRICT induction_bucket, fast_sint_t block_start, fast_sint_t block_size, sa_sint_t threads, LIBSAIS_THREAD_STATE * RESTRICT thread_state)
 {
 #if defined(LIBSAIS_OPENMP)
-    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
+    #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * MAX(k, 256) && omp_get_dynamic() == 0)
 #endif
     {
 #if defined(LIBSAIS_OPENMP)


### PR DESCRIPTION
Under gcc13 we get many warnings like:
```
libsais/src/libsais16.c:2185:84: warning: implicit declaration of function ‘max’ [-Wimplicit-function-declaration]
 2185 |     #pragma omp parallel num_threads(threads) if(threads > 1 && block_size >= 64 * max(k, 256) && omp_get_dynamic() == 0)
```

With gcc14 these turn by default to errors.